### PR TITLE
[PR] How to publish a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1083,6 +1083,17 @@ It helps us to have a perception of how we have to put the code, it serves to te
 [Mockito](https://pub.dev/packages/mockito) is a mocking library that helps us to mock functionality where we don't want to perform a specific action. We try to _avoid_ using mocks as much as possible because they can inadvertently make our tests more complex with limited benefit.
 
 
+There are a myriad of libraries 
+in the Dart ecosystem.
+If you are interested 
+in developing your own and share it with the world,
+you have to know how to *publish* it.
+Luckily for you, we got you covered!
+Check the [`publishing-packaged.md`](./publishing-packages.md)
+file for detailed instructions
+on how to get started! 🎉
+
+
 ## `Dart` VS Javascript:
 
 Dart:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,50 @@ with [`Flutter`](https://github.com/dwyl/learn-flutter)!
 <br />
 </div>
 
+- [What ?](#what-)
+- [Who?](#who)
+- [How?](#how)
+  - [Install `Dart`](#install-dart)
+    - [Mac](#mac)
+    - [Linux](#linux)
+    - [Windows?](#windows)
+  - [`Hello World!`](#hello-world)
+  - [Basic Variables](#basic-variables)
+    - [Using the `var` Keyword](#using-the-var-keyword)
+  - [`Dart` Syntax:](#dart-syntax)
+    - [Variables](#variables)
+      - [The keyword `var`](#the-keyword-var)
+      - [Types](#types)
+      - [The `final` keyword](#the-final-keyword)
+      - [The `const` keyword](#the-const-keyword)
+      - [The `dynamic` keyword](#the-dynamic-keyword)
+      - [The `late` keyword](#the-late-keyword)
+        - [Declaring a non-nullable variable that’s initialized after its declaration.](#declaring-a-non-nullable-variable-thats-initialized-after-its-declaration)
+        - [Lazily initializing a variable.](#lazily-initializing-a-variable)
+    - [`main()` function](#main-function)
+    - [Arrow functions](#arrow-functions)
+    - [Named parameters](#named-parameters)
+  - [Asynchronous events](#asynchronous-events)
+  - [Object-Oriented Programming in Dart](#object-oriented-programming-in-dart)
+    - [Constructor](#constructor)
+    - [Initializer list](#initializer-list)
+    - [inheritance](#inheritance)
+    - [abstract class](#abstract-class)
+    - [Class interface with `implements`](#class-interface-with-implements)
+  - [Useful tools to use with Flutter](#useful-tools-to-use-with-flutter)
+  - [Dartanalyzer](#dartanalyzer)
+  - [Linting](#linting)
+  - [`Dart` Testing](#dart-testing)
+  - [Types of Tests](#types-of-tests)
+    - [Unit Tests](#unit-tests)
+    - [Component Tests](#component-tests)
+    - [End-To-End Tests](#end-to-end-tests)
+  - [Useful libraries in Dart](#useful-libraries-in-dart)
+  - [Publishing Packages to `pub.dev`](#publishing-packages-to-pubdev)
+  - [`Dart` VS Javascript:](#dart-vs-javascript)
+
+
+
 ## Why?
 
 `Dart` is a general purpose programming language
@@ -111,7 +155,7 @@ If you want to build `Flutter` Apps, learn `Dart`;
 this tutorial is the perfect place to start.
 
 
-## What ?
+# What ?
 
 `Dart` is an open-source general-purpose programming language.
 It can be compiled to run as high performance JavaScript in web browsers,
@@ -145,7 +189,7 @@ https://dart.dev/guides
 https://en.wikipedia.org/wiki/Dart_(programming_language)
 
 
-## Who?
+# Who?
 
 This tutorial is for anyone who wants to learn `Dart` from scratch
 without any prior knowledge of other programming languages.
@@ -157,7 +201,7 @@ with `Flutter`.
 
 <br />
 
-## How?
+# How?
 
 We recommend that you `clone` this Git repository 
 so that you can follow along on your `localhost`
@@ -176,7 +220,7 @@ https://dartpad.dartlang.org
 
 <br />
 
-### Install `Dart`
+## Install `Dart`
 
 The official installation instructions are:
 https://dart.dev/get-dart
@@ -240,7 +284,7 @@ have the Flutter SKD embedded.
 
 <br />
 
-## Hello World!
+## `Hello World!`
 
 Once you have installed `Dart` on your `localhost` 
 (_or opened [Dart Pad](https://dartpad.dartlang.org) 
@@ -311,7 +355,7 @@ https://stackoverflow.com/questions/62346301/does-dart-main-function
 
 <br />
 
-## Variables
+## Basic Variables 
 
 The next thing you need to know in `Dart` 
 is how to create variables (_or constants_)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ with [`Flutter`](https://github.com/dwyl/learn-flutter)!
 ## Why?
 
 `Dart` is a general purpose programming language
-that can be used for Servers, Client Apps, Native Mobile Apps
+that can be used for Servers, Client Apps, 
+**_Native_ Mobile Apps**
 and _everything_ in between!
 Google uses `Dart` for several of their high profile products/projects
 including Google Assistant (Client), Google Home Hub
@@ -25,7 +26,8 @@ that don't waste memory or drain the devices' battery,
 use `Dart` and `Flutter`.
 
 
-According to GitHub in 2019, the biggest developer community,
+According to GitHub in 2019, 
+the biggest developer community,
 `Dart` is fastest growing programming language:
 https://octoverse.github.com/#top-languages
 
@@ -1082,14 +1084,26 @@ It helps us to have a perception of how we have to put the code, it serves to te
 
 [Mockito](https://pub.dev/packages/mockito) is a mocking library that helps us to mock functionality where we don't want to perform a specific action. We try to _avoid_ using mocks as much as possible because they can inadvertently make our tests more complex with limited benefit.
 
+## Publishing Packages to `pub.dev`
 
 There are many libraries 
-in the Dart ecosystem.
-If you want
-in developing your own and share it with the world,
+in the Dart ecosystem;
+see:
+[pub.dev/packages](https://pub.dev/packages)
+At the time of writing this doc,
+there are **`30643`** published packages:
+
+<img width="1350" alt="dart pub.dev packages" src="https://user-images.githubusercontent.com/194400/205872136-fbf87baf-e70b-47f2-bfc7-2e693a496dcb.png">
+
+This number grows daily 
+and by the time you read this it might be much higher!
+
+If you want to develop your own package
+and share it with the world,
 you have to know how to *publish* it.
 Luckily for you, we got you covered!
-Check the [`publishing-packaged.md`](./publishing-packages.md)
+Check the 
+[`publishing-packaged.md`](./publishing-packages.md)
 file for detailed instructions
 on how to get started! 🎉
 

--- a/README.md
+++ b/README.md
@@ -1083,7 +1083,7 @@ It helps us to have a perception of how we have to put the code, it serves to te
 [Mockito](https://pub.dev/packages/mockito) is a mocking library that helps us to mock functionality where we don't want to perform a specific action. We try to _avoid_ using mocks as much as possible because they can inadvertently make our tests more complex with limited benefit.
 
 
-There are a myriad of libraries 
+There are many libraries 
 in the Dart ecosystem.
 If you are interested 
 in developing your own and share it with the world,

--- a/README.md
+++ b/README.md
@@ -1085,7 +1085,7 @@ It helps us to have a perception of how we have to put the code, it serves to te
 
 There are many libraries 
 in the Dart ecosystem.
-If you are interested 
+If you want
 in developing your own and share it with the world,
 you have to know how to *publish* it.
 Luckily for you, we got you covered!

--- a/publishing-packages.md
+++ b/publishing-packages.md
@@ -1,21 +1,28 @@
-## Publishing packages with Dart
-The Dart ecosystem is made by packages 
-and libraries that you can import in your
+# Publishing Packages with `Dart`
+
+The `Dart` ecosystem
+is a collection of packages and libraries 
+that you can import in your
 Dart-lang based projects. 
-If you are creating a Flutter app,
-you will notice you'll have a `pubspec.yaml`
+If you are creating a `Flutter` app,
+you will have a 
+`pubspec.yaml`
 file with the dependencies needed
-to properly run it.
+to run it.
 
-Luckily, publishing a package 
+Publishing your own a package(s)
 is fairly simple. 
-All packages reside in https://pub.dev/
-and this is the place we use to publish them.
+All packages are published to:
+[pub.dev](https://pub.dev)
 
-## Before publishing
+
+## _Before_ Publishing
+
 There are some constraints that 
-ought to be met before publishing a package
-in Dart.
+need to be met before publishing a package
+in `Dart`:
+
+
 Firstly, the project should have a 
 `README.md`, a `CHANGELOG.md` and a
 `pubspec.yaml` file 
@@ -24,13 +31,13 @@ about the package - these can be found
 on the package's page, 
 like in the picture below).
 
-![package](https://user-images.githubusercontent.com/17494745/204871000-5e3f2b8b-9f43-4659-824d-3ce181a5d9f8.png)
+![dart-multihash-package](https://user-images.githubusercontent.com/17494745/204871000-5e3f2b8b-9f43-4659-824d-3ce181a5d9f8.png)
 
 
-Here's how the `pubspec.yaml` file
-looks like for the 
+The `pubspec.yaml` file
+for the
 [`dart_multihash`](https://github.com/dwyl/dart_multihash) 
-package.
+package is:
 
 ```yaml
 name: dart_multihash
@@ -60,7 +67,8 @@ amongst other properties effect the
 sidebar of the official page of the package
 after publishing.
 
-### Verified Publishers
+## _Verified_ Publishers
+
 If you have wondered about,
 you might have noticed that 
 lots of packages are published by
@@ -96,9 +104,10 @@ will be associated with.
 For the steps to get this done,
 do visit 
 https://dart.dev/tools/pub/publishing#create-verified-publisher
-.
 
-## Publishing your package
+
+## Publishing Your Package
+
 So let's imagine you've 
 completed your sweet Dart/Flutter
 package and you want to share it
@@ -200,7 +209,8 @@ This means your package has been published!
 :tada:
 Congrats!
 
-## Transfering to a verified publisher
+## Transferring to a Verified Publisher
+
 If you are part of an organization/verified publisher,
 you can transfer your uploaded package
 to it.
@@ -218,4 +228,4 @@ and click on `Transfer to Publisher`.
 organization/publisher to be able
 to transfer ownership**.
 
-And it's as simple as that! :smile:
+And it's as simple as that! 😊

--- a/publishing-packages.md
+++ b/publishing-packages.md
@@ -1,0 +1,221 @@
+## Publishing packages with Dart
+The Dart ecosystem is made by packages 
+and libraries that you can import in your
+Dart-lang based projects. 
+If you are creating a Flutter app,
+you will notice you'll have a `pubspec.yaml`
+file with the dependencies needed
+to properly run it.
+
+Luckily, publishing a package 
+is fairly simple. 
+All packages reside in https://pub.dev/
+and this is the place we use to publish them.
+
+## Before publishing
+There are some constraints that 
+ought to be met before publishing a package
+in Dart.
+Firstly, the project should have a 
+`README.md`, a `CHANGELOG.md` and a
+`pubspec.yaml` file 
+(which is used to fill out the details 
+about the package - these can be found
+on the package's page, 
+like in the picture below).
+
+![package](https://user-images.githubusercontent.com/17494745/204871000-5e3f2b8b-9f43-4659-824d-3ce181a5d9f8.png)
+
+
+Here's how the `pubspec.yaml` file
+looks like for the 
+[`dart_multihash`](https://github.com/dwyl/dart_multihash) 
+package.
+
+```yaml
+name: dart_multihash
+description: A dart-lang implementation of the Multihash protocol.
+version: 0.0.1
+homepage: https://github.com/dwyl/dart_multihash
+repository: https://github.com/dwyl/dart_multihash
+issue_tracker: https://github.com/dwyl/dart_multihash/issues
+
+environment:
+  sdk: '>=2.18.4 <3.0.0'
+
+dependencies:
+  buffer: ^1.1.1
+
+dev_dependencies:
+  lints: ^2.0.0
+  crypto: ^3.0.2
+  convert: ^3.1.1
+  test: ^1.16.0
+  collection: ^1.17.0
+```
+
+The `name`, `description`, `version`, 
+`homepage`, `repository`, `issue tracker`,
+amongst other properties effect the 
+sidebar of the official page of the package
+after publishing.
+
+### Verified Publishers
+If you have wondered about,
+you might have noticed that 
+lots of packages are published by
+...well, publishers.
+
+In the previous picture, 
+regarding the `dart_multihash` package
+you might have noticed that 
+there's a [`dwyl.com`](https://pub.dev/publishers/dwyl.com/packages)
+publisher associated.
+
+There are a few advantages to
+having a verified publisher.
+The users *know* the package domain
+is verified, know the organization 
+behind it is trustworthy and can
+safely use the package. 
+Plus, you get a sweet 
+![tick](https://dart.dev/assets/img/verified-publisher.svg)
+icon!
+
+If you are a person or a group of people
+that is interested in publishing
+under a single name, 
+publishing through a verified publisher
+is the way to go.
+
+You will need your own domain and
+**prove** Google that you own it. 
+That is the domain the publisher
+will be associated with.
+
+For the steps to get this done,
+do visit 
+https://dart.dev/tools/pub/publishing#create-verified-publisher
+.
+
+## Publishing your package
+So let's imagine you've 
+completed your sweet Dart/Flutter
+package and you want to share it
+with the world! 
+
+> There are some differences between
+> Dart and Flutter packages,
+> the main one being that the latter
+> pertains to Flutter apps.
+> Dart packages are more agnostic and
+> not Flutter-specific.
+> 
+> If you were to use Visual Studio
+> and `View -> Command Palette` and
+> try to create a Flutter Package
+> and a Dart Package, 
+> although the project structure 
+> is the same, there are two differences:
+> **`pubspec.yaml` doesn't load 
+> the Flutter SDK in the Dart's package**
+> and the **`analysis_options.yaml` file
+> imports different linting packages**.
+> That's it. :smile:
+
+Even if you are a publisher,
+currently, you can't directly publish 
+your package to your verified
+publisher, you need to upload to your personal account
+and then **transfer it** 
+to the chosen verified publisher.
+
+In your project root,
+go to your terminal and type the following.
+
+```sh
+ dart pub publish --dry-run
+```
+
+This command will make sure
+the package follows the 
+[pubspec format](https://dart.dev/tools/pub/pubspec)
+and [package layout conventions](https://dart.dev/tools/pub/package-layout).
+If your package yields warnings,
+don't worry! 
+Just follow the suggestions 
+(it's usually just linting or renaming files 
+or specifying dependencies) 
+and you should be good to go!
+
+Once there are no issues 
+and you feel you are ready to publish,
+just run the following command!
+
+```sh
+ dart pub publish --dry-run
+```
+
+You should be prompted with the following output.
+
+```
+Publishing is forever; packages cannot be unpublished.
+Policy details are available at https://pub.dev/policy
+
+Do you want to publish dart_multihash 0.0.1 to https://pub.dartlang.org (y/N)?
+```
+
+Press `y`. 
+You should now see the following.
+
+```
+Pub needs your authorization to upload packages on your behalf.
+In a web browser, go to https://accounts.google.com/o/oauth2/auth?axxxx
+Then click "Allow access".
+
+Waiting for your authorization...
+```
+
+Your link will be custom.
+If you visit it in your browser,
+it will ask you to sign-in with your Google account.
+
+![sign-in](https://user-images.githubusercontent.com/17494745/204876805-22f4d144-805a-4a2c-92b8-68df91734c1f.png)
+
+After signing-in, you should be good to go!
+You have now your own profile in https://pub.dev/!
+
+If you authorize it,
+your terminal should display the following.
+
+```
+Waiting for your authorization...
+Authorization received, processing...
+
+Successfully authorized.
+Uploading... (2.2s)
+```
+
+This means your package has been published!
+:tada:
+Congrats!
+
+## Transfering to a verified publisher
+If you are part of an organization/verified publisher,
+you can transfer your uploaded package
+to it.
+To do so, simply head to the package page
+inside https://pub.dev/.
+You will see something similar to this.
+
+<img width="1312" alt="image" src="https://user-images.githubusercontent.com/17494745/204877380-de94c30f-b4ad-49b0-bd95-cf3d91aab8b8.png">
+
+Inside the `Admin` tab, 
+you can **change ownership**.
+Simply select the publisher you want
+and click on `Transfer to Publisher`.
+**You have to be part of the 
+organization/publisher to be able
+to transfer ownership**.
+
+And it's as simple as that! :smile:


### PR DESCRIPTION
closes #22 

This PR adds a file detailing how to publish a package in the Dart ecosystem (following steps from how it was done with [`dart_multihash`](https://github.com/dwyl/dart_multihash) and fixes the README file to refer to this new file.